### PR TITLE
fix: address vault graph review — correctness, performance, and UX issues

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@pagefind/default-ui": "^1.4.0",
         "@unocss/astro": "^66.6.6",
         "astro": "6.0.5",
+        "force-graph": "^1.51.2",
         "hast-util-select": "^6.0.4",
         "katex": "^0.16.38",
         "mdast-util-to-string": "^4.0.0",
@@ -29,6 +30,7 @@
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+        "@types/force-graph": "^1.26.3",
         "@typescript-eslint/parser": "^8.57.1",
         "eslint": "^10.0.3",
         "eslint-plugin-astro": "^1.6.0",
@@ -419,6 +421,8 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@25.0.0", "", {}, "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
@@ -428,6 +432,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/force-graph": ["@types/force-graph@1.26.3", "", { "dependencies": { "force-graph": "*" } }, "sha512-mwhRCYjQVhx/vnkoEzoxEwjkbKDCJUsYoCfCAp+5EJF13YfU2QUlmtbUBDS/aI5BlxLzaSPyAGvb+ebNxF+XoA=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -527,6 +533,8 @@
 
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
 
+    "accessor-fn": ["accessor-fn@1.5.3", "", {}, "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -565,6 +573,8 @@
 
     "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
+    "bezier-js": ["bezier-js@6.1.4", "", {}, "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg=="],
+
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -574,6 +584,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "canvas-color-tracker": ["canvas-color-tracker@1.3.2", "", { "dependencies": { "tinycolor2": "^1.6.0" } }, "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -630,6 +642,44 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-binarytree": ["d3-binarytree@1.0.2", "", {}, "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-force-3d": ["d3-force-3d@3.0.6", "", { "dependencies": { "d3-binarytree": "1", "d3-dispatch": "1 - 3", "d3-octree": "1", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-octree": ["d3-octree@1.1.0", "", {}, "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -755,9 +805,13 @@
 
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
+    "float-tooltip": ["float-tooltip@1.7.5", "", { "dependencies": { "d3-selection": "2 - 3", "kapsule": "^1.16", "preact": "10" } }, "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg=="],
+
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
 
     "fontkitten": ["fontkitten@1.0.2", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q=="],
+
+    "force-graph": ["force-graph@1.51.2", "", { "dependencies": { "@tweenjs/tween.js": "18 - 25", "accessor-fn": "1", "bezier-js": "3 - 6", "canvas-color-tracker": "^1.3", "d3-array": "1 - 3", "d3-drag": "2 - 3", "d3-force-3d": "2 - 3", "d3-scale": "1 - 4", "d3-scale-chromatic": "1 - 3", "d3-selection": "2 - 3", "d3-zoom": "2 - 3", "float-tooltip": "^1.7", "index-array-by": "1", "kapsule": "^1.16", "lodash-es": "4" } }, "sha512-zZNdMqx8qIQGurgnbgYIUsdXxSfvhfRSIdncsKGv/twUOZpwCsk9hPHmdjdcme1+epATgb41G0rkIGHJ0Wydng=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -823,7 +877,11 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "index-array-by": ["index-array-by@1.4.2", "", {}, "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -869,6 +927,8 @@
 
     "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
+    "kapsule": ["kapsule@1.16.3", "", { "dependencies": { "lodash-es": "4" } }, "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg=="],
+
     "katex": ["katex@0.16.38", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
@@ -878,6 +938,8 @@
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -1103,6 +1165,8 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
@@ -1248,6 +1312,8 @@
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@pagefind/default-ui": "^1.4.0",
     "@unocss/astro": "^66.6.6",
     "astro": "6.0.5",
+    "force-graph": "^1.51.2",
     "hast-util-select": "^6.0.4",
     "katex": "^0.16.38",
     "mdast-util-to-string": "^4.0.0",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+    "@types/force-graph": "^1.26.3",
     "@typescript-eslint/parser": "^8.57.1",
     "eslint": "^10.0.3",
     "eslint-plugin-astro": "^1.6.0",

--- a/src/components/pages/TOC.astro
+++ b/src/components/pages/TOC.astro
@@ -88,8 +88,8 @@ const toc = generateToc(headings)
       })
 
       this.tocLinks.forEach(({ element: el, progressBar: bar, slug }, i) => {
-        const { inView, progress } = this.headingProgress[slug]
         if (this.headingProgress[slug]) {
+          const { inView, progress } = this.headingProgress[slug]
           if (inView && firstInViewIndex === -1) {
              firstInViewIndex = i;
           }
@@ -97,13 +97,13 @@ const toc = generateToc(headings)
           el.classList.toggle('highlight-bg-translucent', inView)
           el.classList.toggle(
             'rounded-t-2xl',
-            inView && (i === 0 || !this.headingProgress[this.tocLinks[i - 1]?.slug].inView)
+            inView && (i === 0 || !this.headingProgress[this.tocLinks[i - 1]?.slug]?.inView)
           )
           el.classList.toggle(
             'rounded-b-2xl',
             inView &&
               (i === this.tocLinks.length - 1 ||
-                !this.headingProgress[this.tocLinks[i + 1]?.slug].inView)
+                !this.headingProgress[this.tocLinks[i + 1]?.slug]?.inView)
           )
           bar.classList.toggle('is-read', !inView && progress === 1)
           bar.classList.toggle('highlight-bg', inView)

--- a/src/components/pages/TOC.astro
+++ b/src/components/pages/TOC.astro
@@ -3,6 +3,7 @@ import type { MarkdownHeading } from 'astro'
 
 import { generateToc } from '../../plugins/toc'
 import TOCHeading from './TOCHeading.astro'
+import { Icon } from '@/components/user'
 
 interface Props {
   headings: MarkdownHeading[]
@@ -16,10 +17,17 @@ const toc = generateToc(headings)
 ---
 
 <toc-heading class={className} {...props}>
-  <h2 class='font-medium'>TABLE OF CONTENTS</h2>
-  <ul class='mt-4'>
-    {toc.map((heading) => <TOCHeading heading={heading} />)}
-  </ul>
+  <details class="group" open>
+    <summary class='font-semibold py-2 flex items-center justify-between text-muted-foreground uppercase text-xs tracking-wider cursor-pointer list-none select-none hover:text-foreground mb-2'>
+      <span class='flex items-center gap-2'>
+         TABLE OF CONTENTS
+      </span>
+      <Icon name='chevron-down' class='size-4 transition-transform duration-200 group-open:rotate-180' />
+    </summary>
+    <ul class='mt-2'>
+      {toc.map((heading) => <TOCHeading heading={heading} />)}
+    </ul>
+  </details>
 </toc-heading>
 
 <script>
@@ -42,6 +50,7 @@ const toc = generateToc(headings)
     headings: HTMLElement[] = []
     tocLinks: TOCLink[] = []
     headingProgress: Record<string, HeadingProgress> = {}
+    lastActiveLinkIndex = -1
 
     constructor() {
       super()
@@ -65,6 +74,8 @@ const toc = generateToc(headings)
       const postOffset =
         ((document.querySelector('#content') as HTMLElement)?.offsetHeight || 0) + 127
 
+      let firstInViewIndex = -1;
+
       this.headings.forEach((el, index) => {
         const nextHeadingTop = this.headings[index + 1]?.offsetTop || postOffset
         const range = [el.offsetTop - pageOffset, nextHeadingTop - pageOffset - el.offsetHeight]
@@ -79,6 +90,9 @@ const toc = generateToc(headings)
       this.tocLinks.forEach(({ element: el, progressBar: bar, slug }, i) => {
         const { inView, progress } = this.headingProgress[slug]
         if (this.headingProgress[slug]) {
+          if (inView && firstInViewIndex === -1) {
+             firstInViewIndex = i;
+          }
           el.classList.toggle('highlight', inView)
           el.classList.toggle('highlight-bg-translucent', inView)
           el.classList.toggle(
@@ -96,6 +110,23 @@ const toc = generateToc(headings)
           bar.style.setProperty('height', `${progress * 90}%`)
         }
       })
+      
+      if (firstInViewIndex !== -1 && firstInViewIndex !== this.lastActiveLinkIndex) {
+         this.lastActiveLinkIndex = firstInViewIndex;
+         const sidebar = document.getElementById('sidebar');
+         if (sidebar) {
+             if (firstInViewIndex === 0) {
+                 sidebar.scrollTo({ top: 0, behavior: 'smooth' });
+             } else {
+                 const el = this.tocLinks[firstInViewIndex].element;
+                 const sidebarRect = sidebar.getBoundingClientRect();
+                 const elRect = el.getBoundingClientRect();
+                 if (elRect.top < sidebarRect.top + 80 || elRect.bottom > sidebarRect.bottom - 80) {
+                     sidebar.scrollBy({ top: (elRect.top - sidebarRect.top) - (sidebarRect.height / 3), behavior: 'smooth' });
+                 }
+             }
+         }
+      }
     }
 
     connectedCallback() {

--- a/src/components/vault/Backlinks.astro
+++ b/src/components/vault/Backlinks.astro
@@ -1,0 +1,50 @@
+---
+import { Icon } from '@/components/user'
+import { getVaultGraphData } from '@/utils/graph'
+
+interface Props {
+  currentSlug?: string
+}
+
+const { currentSlug } = Astro.props
+const graphData = await getVaultGraphData()
+
+let backlinks: { title: string; url: string }[] = []
+
+if (currentSlug && graphData.backlinksMap[currentSlug]) {
+  const linkingSlugs = graphData.backlinksMap[currentSlug]
+  backlinks = linkingSlugs.map((slug) => {
+    const node = graphData.nodes.find((n) => n.id === slug)
+    return {
+      title: node?.name || slug,
+      url: `/vault/${slug}`
+    }
+  })
+}
+---
+
+{
+  backlinks.length > 0 && (
+    <details class='group mt-6 border-t border-border/50 pt-4' open>
+      <summary class='font-semibold py-2 flex items-center justify-between text-muted-foreground uppercase text-xs tracking-wider cursor-pointer list-none select-none hover:text-foreground'>
+        <span class='flex items-center gap-2'>
+          Backlinks
+          <Icon name='link' class='size-4' />
+        </span>
+        <Icon name='chevron-down' class='size-4 transition-transform duration-200 group-open:rotate-180' />
+      </summary>
+      <ul class='flex flex-col mt-2 py-1 list-none overflow-hidden space-y-1'>
+        {backlinks.map((link) => (
+          <li class='group'>
+            <a
+              href={link.url}
+              class='block py-2 px-3 rounded-md text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-all duration-200'
+            >
+              {link.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </details>
+  )
+}

--- a/src/components/vault/VaultGraph.astro
+++ b/src/components/vault/VaultGraph.astro
@@ -1,0 +1,380 @@
+---
+import { Icon } from '@/components/user'
+import { getVaultGraphData } from '@/utils/graph'
+
+interface Props {
+  localSlug?: string
+  width?: number | string
+  height?: number | string
+  class?: string
+}
+
+const { localSlug, width = '100%', height = '250px', class: className } = Astro.props
+const allData = await getVaultGraphData()
+
+let localData = { nodes: allData.nodes, links: allData.links }
+
+if (localSlug) {
+  // Build neighborhood
+  const neighbors = new Set<string>()
+  neighbors.add(localSlug)
+
+  if (allData.linksMap[localSlug]) {
+    allData.linksMap[localSlug].forEach((n) => neighbors.add(n))
+  }
+  if (allData.backlinksMap[localSlug]) {
+    allData.backlinksMap[localSlug].forEach((n) => neighbors.add(n))
+  }
+
+  const localNodes = allData.nodes.filter((n) => neighbors.has(n.id))
+  // only keep links between neighbors
+  const localLinks = allData.links.filter((l) => neighbors.has(l.source) && neighbors.has(l.target))
+
+  localData = { nodes: localNodes, links: localLinks }
+}
+---
+
+<div
+  class={`flex flex-col ${className || ''}`}
+  id={`vault-graph-component-${localSlug || 'global'}`}
+>
+  <!-- Iris-style Header -->
+  {
+    localSlug ? (
+      <details class='group' open>
+        <summary class='flex items-center justify-between mb-3 pl-1 font-semibold text-muted-foreground uppercase text-xs tracking-wider cursor-pointer list-none select-none hover:text-foreground'>
+          <span class='flex items-center gap-2'>
+            Graph
+          </span>
+          <div class='flex items-center gap-2'>
+            <slot name='controls'>
+              <button
+                class='global-graph-btn text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm cursor-pointer'
+                title='Global Graph'
+                aria-label='Open Global Graph'
+              >
+                <svg
+                  class='size-4'
+                  xmlns='http://www.w3.org/2000/svg'
+                  width='1em'
+                  height='1em'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    fill='none'
+                    stroke='currentColor'
+                    stroke-linecap='round'
+                    stroke-linejoin='round'
+                    stroke-miterlimit='10'
+                    d='M13.5 13.25L10 15.5l-3.5-2.25v-3.5L10 7.5l3.5 2.25zm-9-6.5L2.5 8l-2-1.25v-2l2-1.25l2 1.25zm15-2L17.5 6l-2-1.25v-2l2-1.25l2 1.25zm-15 16.5l-2 1.25l-2-1.25v-2l2-1.25l2 1.25zm16.5 1l-2 1.25l-2-1.25v-2L19 19l2 1.25zm1.5-9.75l-2 1.25l-2-1.25v-2l2-1.25l2 1.25zm-16-2.75L3.813 7.18m13.883 12.635l-5.968-5.426M18.5 11.5h-5m-5.548 2.684l-4.27 4.555M16.318 5.261l-3.686 3.931'
+                  />
+                </svg>
+              </button>
+            </slot>
+            <Icon name='chevron-down' class='size-4 transition-transform duration-200 group-open:rotate-180' />
+          </div>
+        </summary>
+        <div
+          class='relative overflow-hidden rounded-lg border border-border/70 bg-transparent'
+          style={{
+            height: typeof height === 'number' ? `${height}px` : height,
+            width: typeof width === 'number' ? `${width}px` : width
+          }}
+        >
+          <div
+            class='vault-graph w-full h-full'
+            data-graph={JSON.stringify(localData)}
+            data-local={localSlug || ''}
+          >
+          </div>
+        </div>
+      </details>
+    ) : (
+      <div
+        class='relative overflow-hidden rounded-lg border border-border/70 bg-transparent'
+        style={{
+          height: typeof height === 'number' ? `${height}px` : height,
+          width: typeof width === 'number' ? `${width}px` : width
+        }}
+      >
+        <div
+          class='vault-graph w-full h-full'
+          data-graph={JSON.stringify(localData)}
+          data-local={localSlug || ''}
+        >
+        </div>
+      </div>
+    )
+  }
+
+  <!-- Global Graph Overlay Modal -->
+  {
+    localSlug && (
+      <dialog class='vault-global-graph-modal fixed inset-0 w-screen h-[100dvh] max-h-screen m-0 p-0 z-[100] bg-background/80 backdrop-blur-md border-none shadow-none text-foreground opacity-0 pointer-events-none transition-opacity duration-300'>
+        <div class='w-full h-full flex flex-col p-4 md:p-8'>
+          <div class='flex items-center justify-between mb-4 z-10 flex-shrink-0'>
+            <h2 class='font-medium text-muted-foreground uppercase tracking-widest text-sm flex items-center gap-2'>
+              <svg
+                class='size-5'
+                xmlns='http://www.w3.org/2000/svg'
+                width='1em'
+                height='1em'
+                viewBox='0 0 24 24'
+              >
+                <path
+                  fill='none'
+                  stroke='currentColor'
+                  stroke-linecap='round'
+                  stroke-linejoin='round'
+                  stroke-miterlimit='10'
+                  d='M13.5 13.25L10 15.5l-3.5-2.25v-3.5L10 7.5l3.5 2.25zm-9-6.5L2.5 8l-2-1.25v-2l2-1.25l2 1.25zm15-2L17.5 6l-2-1.25v-2l2-1.25l2 1.25zm-15 16.5l-2 1.25l-2-1.25v-2l2-1.25l2 1.25zm16.5 1l-2 1.25l-2-1.25v-2L19 19l2 1.25zm1.5-9.75l-2 1.25l-2-1.25v-2l2-1.25l2 1.25zm-16-2.75L3.813 7.18m13.883 12.635l-5.968-5.426M18.5 11.5h-5m-5.548 2.684l-4.27 4.555M16.318 5.261l-3.686 3.931'
+                />
+              </svg>
+              VAULT GRAPH
+            </h2>
+            <button
+              class='close-global-graph hover:bg-muted p-2 rounded-full cursor-pointer transition-colors'
+              aria-label='Close Global Graph'
+            >
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='20'
+                height='20'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                stroke-width='2'
+                stroke-linecap='round'
+                stroke-linejoin='round'
+              >
+                <>
+                  <line x1='18' y1='6' x2='6' y2='18' />
+                  <line x1='6' y1='6' x2='18' y2='18' />
+                </>
+              </svg>
+            </button>
+          </div>
+          <div class='flex-1 w-full bg-card rounded-xl border border-border/50 overflow-hidden relative shadow-2xl'>
+            <div
+              class='vault-graph w-full h-full'
+              data-graph={JSON.stringify({ nodes: allData.nodes, links: allData.links })}
+              data-global='true'
+            />
+          </div>
+        </div>
+      </dialog>
+    )
+  }
+</div>
+
+<script>
+  import ForceGraph from 'force-graph'
+
+  function createGraph(container: any, gData: any, localSlug: string) {
+    const wrapper = container.parentElement
+    if (!wrapper) return null
+
+    const style = getComputedStyle(document.body)
+    const parseHsl = (varName: string, alpha = 1) => {
+      const val = style.getPropertyValue(varName).trim()
+      if (!val) return `rgba(150, 150, 150, ${alpha})`
+      return `hsl(${val.replace(/\s+/g, ', ')}, ${alpha})`
+    }
+
+    const primary = parseHsl('--primary')
+
+    let hoverNode: any = null
+    let hoverNeighbors = new Set<string>()
+
+    // @ts-ignore
+    const ForceGraphFn = (ForceGraph.default || ForceGraph) as any
+    const Graph = ForceGraphFn()
+
+    Graph(container)
+      .graphData(gData)
+      .width(wrapper.offsetWidth)
+      .height(wrapper.offsetHeight)
+      .nodeId('id')
+      .nodeLabel('name')
+      .nodeVal('val')
+      .onNodeHover((node: any) => {
+        hoverNode = node
+        hoverNeighbors.clear()
+        if (node) {
+          gData.links.forEach((l: any) => {
+            if (l.source.id === node.id || l.target.id === node.id) {
+              hoverNeighbors.add(l.source.id)
+              hoverNeighbors.add(l.target.id)
+            }
+          })
+        }
+      })
+      .linkColor((link: any) => {
+        if (hoverNode) {
+          const connected = link.source.id === hoverNode.id || link.target.id === hoverNode.id
+          return connected
+            ? parseHsl('--muted-foreground', 0.6)
+            : parseHsl('--muted-foreground', 0.1)
+        }
+        return parseHsl('--muted-foreground', 0.3)
+      })
+      .linkWidth((link: any) => {
+        if (hoverNode) {
+          return link.source.id === hoverNode.id || link.target.id === hoverNode.id ? 1.5 : 1
+        }
+        return 1
+      })
+      .linkDirectionalArrowLength(3.5)
+      .linkDirectionalArrowRelPos(1)
+      .nodeCanvasObject((node: any, ctx: any, globalScale: any) => {
+        const isNeighbor = hoverNeighbors.has(node.id)
+        const isHovered = hoverNode === node
+        const isActive = localSlug && node.id === localSlug
+
+        let alpha = 1
+        if (hoverNode && !isNeighbor && !isHovered) {
+          alpha = 0.2
+        }
+
+        const isGlobal = !localSlug
+        const rMultiplier = isGlobal ? 3.5 : 2.5
+        const rBase = isGlobal ? 5 : 4
+        const r = Math.max(rBase, Math.sqrt(node.val) * rMultiplier)
+
+        ctx.beginPath()
+        ctx.arc(node.x, node.y, r, 0, 2 * Math.PI, false)
+
+        if (isActive) {
+          ctx.fillStyle = primary
+        } else if (node.id.startsWith('tags/')) {
+          ctx.fillStyle = parseHsl('--background')
+        } else {
+          ctx.fillStyle = parseHsl('--muted-foreground', 0.4 * alpha)
+        }
+        ctx.fill()
+
+        ctx.lineWidth = isActive ? 2 : 1
+        if (isActive) {
+          ctx.strokeStyle = primary
+        } else if (node.id.startsWith('tags/')) {
+          ctx.strokeStyle = parseHsl('--primary', 0.6 * alpha)
+        } else {
+          ctx.strokeStyle = parseHsl('--border', alpha * 0.8)
+        }
+        ctx.stroke()
+
+        // Clean node design (No internal emojis/icons)
+
+        const labelThreshold = isGlobal ? 0.6 : 1.2
+        const showLabel = isActive || isHovered || globalScale > labelThreshold
+        if (showLabel) {
+          const label = node.name
+          const fontSize = 11 / globalScale
+          ctx.font = `${fontSize}px "Satoshi", sans-serif`
+          ctx.textAlign = 'center'
+          ctx.textBaseline = 'top'
+          ctx.fillStyle = isActive ? primary : parseHsl('--foreground', alpha * 0.85)
+          ctx.fillText(label, node.x, node.y + r + 3)
+        }
+      })
+      .onNodeClick((node: any) => {
+        window.location.href = `/vault/${node.id}`
+      })
+
+    // @ts-ignore
+    Graph.d3Force('charge').strength(-180).distanceMax(250)
+    // @ts-ignore
+    Graph.d3Force('link').distance(40)
+    // @ts-ignore
+    Graph.d3Force('center').strength(0.4)
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (wrapper.offsetWidth > 0 && wrapper.offsetHeight > 0) {
+        Graph.width(wrapper.offsetWidth)
+        Graph.height(wrapper.offsetHeight)
+      }
+    })
+    resizeObserver.observe(wrapper)
+
+    return Graph
+  }
+
+  function initGraphs() {
+    // 1. Initialize inline standard graphs
+    const inlineContainers = document.querySelectorAll('.vault-graph:not([data-global="true"])')
+    inlineContainers.forEach((container) => {
+      // @ts-ignore
+      if (container.dataset.rendered === 'true') return
+      // @ts-ignore
+      container.dataset.rendered = 'true'
+      // @ts-ignore
+      const rawData = container.dataset.graph
+      if (!rawData) return
+      const gData = JSON.parse(rawData)
+      // @ts-ignore
+      createGraph(container, gData, container.dataset.local || '')
+    })
+
+    // 2. Map Dialog Toggles
+    const components = document.querySelectorAll('[id^="vault-graph-component-"]')
+    components.forEach((comp) => {
+      // @ts-ignore
+      if (comp.dataset.modalSetup === 'true') return
+      // @ts-ignore
+      comp.dataset.modalSetup = 'true'
+
+      const btn = comp.querySelector('.global-graph-btn')
+      const modal = comp.querySelector('.vault-global-graph-modal')
+      const closeBtn = comp.querySelector('.close-global-graph')
+      const globalGraphContainer = comp.querySelector('.vault-graph[data-global="true"]')
+
+      if (btn && modal && globalGraphContainer) {
+        let globalGraphInstance: any = null
+
+        btn.addEventListener('click', () => {
+          // @ts-ignore
+          modal.showModal()
+          modal.classList.remove('opacity-0', 'pointer-events-none')
+          document.body.style.overflow = 'hidden'
+
+          if (!globalGraphInstance) {
+            // @ts-ignore
+            const rawData = globalGraphContainer.dataset.graph
+            if (rawData) {
+              // Wait a microtick for dialog to layout its dimensions
+              setTimeout(() => {
+                const gData = JSON.parse(rawData)
+                globalGraphInstance = createGraph(globalGraphContainer, gData, '')
+              }, 10)
+            }
+          }
+        })
+
+        const closeModal = () => {
+          modal.classList.add('opacity-0', 'pointer-events-none')
+          document.body.style.overflow = ''
+          setTimeout(() => {
+            // @ts-ignore
+            modal.close()
+          }, 300)
+        }
+
+        if (closeBtn) closeBtn.addEventListener('click', closeModal)
+
+        modal.addEventListener('close', () => {
+          modal.classList.add('opacity-0', 'pointer-events-none')
+          document.body.style.overflow = ''
+        })
+
+        modal.addEventListener('click', (e) => {
+          if (e.target === modal) {
+            closeModal()
+          }
+        })
+      }
+    })
+  }
+
+  document.addEventListener('astro:page-load', initGraphs)
+  initGraphs()
+</script>

--- a/src/components/vault/VaultGraph.astro
+++ b/src/components/vault/VaultGraph.astro
@@ -52,6 +52,7 @@ if (localSlug) {
                 class='global-graph-btn text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded-sm cursor-pointer'
                 title='Global Graph'
                 aria-label='Open Global Graph'
+                onclick='event.preventDefault(); event.stopPropagation();'
               >
                 <svg
                   class='size-4'
@@ -157,7 +158,6 @@ if (localSlug) {
           <div class='flex-1 w-full bg-card rounded-xl border border-border/50 overflow-hidden relative shadow-2xl'>
             <div
               class='vault-graph w-full h-full'
-              data-graph={JSON.stringify({ nodes: allData.nodes, links: allData.links })}
               data-global='true'
             />
           </div>
@@ -178,7 +178,7 @@ if (localSlug) {
     const parseHsl = (varName: string, alpha = 1) => {
       const val = style.getPropertyValue(varName).trim()
       if (!val) return `rgba(150, 150, 150, ${alpha})`
-      return `hsl(${val.replace(/\s+/g, ', ')}, ${alpha})`
+      return `hsl(${val} / ${alpha})`
     }
 
     const primary = parseHsl('--primary')
@@ -338,15 +338,16 @@ if (localSlug) {
           document.body.style.overflow = 'hidden'
 
           if (!globalGraphInstance) {
-            // @ts-ignore
-            const rawData = globalGraphContainer.dataset.graph
-            if (rawData) {
-              // Wait a microtick for dialog to layout its dimensions
-              setTimeout(() => {
-                const gData = JSON.parse(rawData)
+            // Lazily fetch global graph data on first open to avoid embedding it in every page
+            setTimeout(async () => {
+              try {
+                const response = await fetch('/vault/graph.json')
+                const gData = await response.json()
                 globalGraphInstance = createGraph(globalGraphContainer, gData, '')
-              }, 10)
-            }
+              } catch (err) {
+                console.error('Failed to load global graph data. Please refresh the page or check your network connection.', err)
+              }
+            }, 10)
           }
         })
 

--- a/src/layouts/VaultLayout.astro
+++ b/src/layouts/VaultLayout.astro
@@ -3,6 +3,8 @@ import PageLayout from '@/layouts/BaseLayout.astro'
 import { FormattedDate, Icon } from '@/components/user'
 import type { SiteMeta } from '@/types/config'
 import VaultTree from '@/components/vault/VaultTree.astro'
+import VaultGraph from '@/components/vault/VaultGraph.astro'
+import Backlinks from '@/components/vault/Backlinks.astro'
 import { ArticleBottom, BackToTop, Copyright, TOC } from '@/components/pages'
 
 // Plugin styles
@@ -142,7 +144,7 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
     </main>
     <!-- Right Sidebar: TOC -->
     <aside 
-       class='animate lg:w-64 shrink-0 lg:sticky lg:top-24 hidden xl:block pl-4 z-40 fixed lg:order-2 lg:shrink-0 max-lg:border max-lg:px-4 max-lg:py-3 max-lg:bg-muted max-lg:rounded-xl right-0 top-20 h-[calc(100vh-7rem)] overflow-y-scroll max-lg:hidden'
+       class='animate lg:w-64 shrink-0 lg:sticky lg:top-24 hidden xl:block pl-4 z-40 fixed lg:order-2 lg:shrink-0 max-lg:border max-lg:px-4 max-lg:py-3 max-lg:bg-muted max-lg:rounded-xl right-0 top-20 h-[calc(100vh-7rem)] overflow-y-auto custom-scrollbar max-lg:hidden'
        id='sidebar'
     >
         <!-- Mobile Vault Navigation (Inside Drawer) -->
@@ -161,9 +163,16 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
         </details>
 
         {!!headings?.length && (
-            <div class='max-h-[calc(100vh-10rem)] overflow-y-auto custom-scrollbar pr-2 text-sm'>
+            <div class='pr-2 text-sm'>
                 <TOC {headings} />
             </div>
+        )}
+
+        {currentSlug && (
+          <div class="mt-8 pr-2">
+             <VaultGraph localSlug={currentSlug} height={200} class="mb-4" />
+             <Backlinks currentSlug={currentSlug} />
+          </div>
         )}
     </aside>
 

--- a/src/pages/vault/[...slug].astro
+++ b/src/pages/vault/[...slug].astro
@@ -9,7 +9,7 @@ import { getEnrichedVaultCollection, getVaultFlatList } from '@/utils/vault'
 export const prerender = true
 
 export async function getStaticPaths() {
-  const vault = await getEnrichedVaultCollection()
+  const vault = await getEnrichedVaultCollection({ type: 'vault' })
   return vault.map((entry) => ({
     params: { slug: entry.slug },
     props: { entry, slug: entry.slug }

--- a/src/pages/vault/graph.json.ts
+++ b/src/pages/vault/graph.json.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from 'astro'
+import { getVaultGraphData } from '@/utils/graph'
+
+export const prerender = true
+
+export const GET: APIRoute = async () => {
+  const { nodes, links } = await getVaultGraphData()
+  return new Response(JSON.stringify({ nodes, links }), {
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -25,7 +25,8 @@ let cachedGraphData: GraphData | null = null
 export async function getVaultGraphData(): Promise<GraphData> {
   if (cachedGraphData) return cachedGraphData
 
-  const entries = await getEnrichedVaultCollection()
+  // Only include vault-type entries; blog posts are served under /blog and have their own route
+  const entries = await getEnrichedVaultCollection({ type: 'vault' })
   const nodes: GraphNode[] = []
   const links: GraphLink[] = []
   
@@ -34,6 +35,16 @@ export async function getVaultGraphData(): Promise<GraphData> {
 
   // 1. Create a set of all valid slugs we can link to
   const validSlugs = new Set(entries.map(e => e.slug))
+
+  // Precompute basename -> matching slugs map for O(1) fallback lookups
+  const basenameMap = new Map<string, string[]>()
+  for (const slug of validSlugs) {
+    const basename = slug.split('/').pop()
+    if (!basename) continue
+    const existing = basenameMap.get(basename)
+    if (existing) existing.push(slug)
+    else basenameMap.set(basename, [slug])
+  }
 
   // Helper to init sets and add links
   const addLink = (source: string, target: string) => {
@@ -68,9 +79,9 @@ export async function getVaultGraphData(): Promise<GraphData> {
       if (validSlugs.has(targetSlug)) {
         addLink(sourceSlug, targetSlug)
       } else {
-        // sometimes wikilinks omit the folder path, let's try to match by basename
-        const possibleTargets = Array.from(validSlugs).filter(s => s.endsWith(targetSlug))
-        if (possibleTargets.length === 1) {
+        // Wikilinks sometimes omit the folder path; use precomputed map for O(1) basename lookup
+        const possibleTargets = basenameMap.get(targetSlug)
+        if (possibleTargets?.length === 1) {
            addLink(sourceSlug, possibleTargets[0])
         }
       }
@@ -92,11 +103,11 @@ export async function getVaultGraphData(): Promise<GraphData> {
       if (validSlugs.has(resolved)) {
         addLink(sourceSlug, resolved)
       } else {
-        // Try to match just the base name natively
+        // Try to match just the base name; use precomputed map for O(1) lookup
         const baseName = cleanHref.split('/').pop() || ''
         const baseSlug = normalizeVaultSlug(baseName)
-        const possibleTargets = Array.from(validSlugs).filter(s => s.endsWith(baseSlug))
-        if (possibleTargets.length === 1) {
+        const possibleTargets = basenameMap.get(baseSlug)
+        if (possibleTargets?.length === 1) {
            addLink(sourceSlug, possibleTargets[0])
         }
       }

--- a/src/utils/graph.ts
+++ b/src/utils/graph.ts
@@ -1,0 +1,133 @@
+import { getEnrichedVaultCollection, normalizeVaultSlug } from '@/utils/vault'
+
+export interface GraphNode {
+  id: string
+  name: string
+  val: number
+  group: string
+}
+
+export interface GraphLink {
+  source: string
+  target: string
+}
+
+export interface GraphData {
+  nodes: GraphNode[]
+  links: GraphLink[]
+  backlinksMap: Record<string, string[]> // targetSlug -> array of sourceSlugs
+  linksMap: Record<string, string[]> // sourceSlug -> array of targetSlugs
+}
+
+// Cache in-memory for static builds
+let cachedGraphData: GraphData | null = null
+
+export async function getVaultGraphData(): Promise<GraphData> {
+  if (cachedGraphData) return cachedGraphData
+
+  const entries = await getEnrichedVaultCollection()
+  const nodes: GraphNode[] = []
+  const links: GraphLink[] = []
+  
+  const backlinksMap: Record<string, Set<string>> = {}
+  const linksMap: Record<string, Set<string>> = {}
+
+  // 1. Create a set of all valid slugs we can link to
+  const validSlugs = new Set(entries.map(e => e.slug))
+
+  // Helper to init sets and add links
+  const addLink = (source: string, target: string) => {
+    if (!linksMap[source]) linksMap[source] = new Set()
+    if (!backlinksMap[target]) backlinksMap[target] = new Set()
+    linksMap[source].add(target)
+    backlinksMap[target].add(source)
+  }
+
+  // 2. Extract links
+  for (const entry of entries) {
+    const sourceSlug = entry.slug
+    
+    nodes.push({
+      id: sourceSlug,
+      name: entry.data.title || sourceSlug,
+      group: (entry.data.tags?.length ? (entry.data.tags[0]?.toLowerCase() ?? 'note') : (sourceSlug.split('/')[0] || 'note')) as string,
+      val: 2
+    })
+
+    if (!entry.body) continue
+
+    // Find wikilinks [[Link]] or [[Link|Alias]]
+    const wikiLinkRegex = /\[\[(.*?)\]\]/g
+    let match
+    while ((match = wikiLinkRegex.exec(entry.body)) !== null) {
+      const inner = match[1]
+      const target = inner.split('|')[0].trim() // use actual target, ignore alias
+      const targetSlug = normalizeVaultSlug(target)
+      
+      // If it's a valid targeted file
+      if (validSlugs.has(targetSlug)) {
+        addLink(sourceSlug, targetSlug)
+      } else {
+        // sometimes wikilinks omit the folder path, let's try to match by basename
+        const possibleTargets = Array.from(validSlugs).filter(s => s.endsWith(targetSlug))
+        if (possibleTargets.length === 1) {
+           addLink(sourceSlug, possibleTargets[0])
+        }
+      }
+    }
+
+    // Find standard markdown links [text](./path/to/note)
+    const mdLinkRegex = /\[([^\]]+)\]\(([^)"]+)(?: "[^"]*")?\)/g
+    let mdMatch
+    while ((mdMatch = mdLinkRegex.exec(entry.body)) !== null) {
+      const href = mdMatch[2].trim()
+      // Skip external links and anchors
+      if (href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto:')) continue
+      
+      const cleanHref = href.split('#')[0].split('?')[0]
+      if (!cleanHref) continue
+      
+      // Clean relative paths
+      const resolved = normalizeVaultSlug(cleanHref.replace(/^(?:\.\.\/)+|^(?:\.\/)+/, ''))
+      if (validSlugs.has(resolved)) {
+        addLink(sourceSlug, resolved)
+      } else {
+        // Try to match just the base name natively
+        const baseName = cleanHref.split('/').pop() || ''
+        const baseSlug = normalizeVaultSlug(baseName)
+        const possibleTargets = Array.from(validSlugs).filter(s => s.endsWith(baseSlug))
+        if (possibleTargets.length === 1) {
+           addLink(sourceSlug, possibleTargets[0])
+        }
+      }
+    }
+  }
+
+  // 3. Compile final arrays
+  for (const source in linksMap) {
+    for (const target of linksMap[source]) {
+      links.push({ source, target })
+    }
+  }
+
+  // Convert Sets to Arrays
+  const finalLinksMap: Record<string, string[]> = {}
+  const finalBacklinksMap: Record<string, string[]> = {}
+  
+  for (const k in linksMap) finalLinksMap[k] = Array.from(linksMap[k])
+  for (const k in backlinksMap) finalBacklinksMap[k] = Array.from(backlinksMap[k])
+
+  // Increase node value based on backlink count to make heavily linked nodes bigger
+  for (const node of nodes) {
+    node.val = 2 + (finalBacklinksMap[node.id]?.length || 0) * 0.5
+  }
+
+  cachedGraphData = {
+    nodes,
+    links,
+    backlinksMap: finalBacklinksMap,
+    linksMap: finalLinksMap
+  }
+
+  return cachedGraphData
+}


### PR DESCRIPTION
Addresses all issues flagged in the PR review: incorrect routing for blog posts in graph/vault contexts, O(n²) link resolution, a TOC crash, broken HSL color output, accordion UX, and per-page graph payload bloat.

## Routing correctness

- `getVaultGraphData()` and `vault/[...slug].astro` `getStaticPaths()` now filter to `type: 'vault'` entries — blog posts (served under `/blog`) are excluded from graph nodes, backlinks, and static vault routes, preventing broken navigation and duplicate URLs.

## Performance

Replaced O(#links × #entries) basename scans with a precomputed `Map<basename, slug[]>` built once before the loop:

```ts
// Before — O(n) scan per unresolved link
const possibleTargets = Array.from(validSlugs).filter(s => s.endsWith(targetSlug))

// After — O(1) lookup
const possibleTargets = basenameMap.get(targetSlug)
```

## TOC crash fix

`headingProgress[slug]` destructuring was happening before the undefined guard. Moved inside the guard; also added `?.` on adjacent-heading accesses for the same reason.

## VaultGraph fixes

- **`parseHsl()`** — was returning invalid `hsl(h, s%, l%, alpha)`; changed to `hsl(${val} / ${alpha})` to match the repo's space-separated CSS variable convention.
- **Global graph button** — added `event.preventDefault(); event.stopPropagation()` so clicking it inside `<summary>` doesn't also toggle the accordion.
- **Lazy-load global graph** — extracted graph data to a static `/vault/graph.json` endpoint (`src/pages/vault/graph.json.ts`); modal fetches it on first open instead of embedding the full payload in every vault page's HTML.